### PR TITLE
NTP config moved to config.h; minor bugfixes

### DIFF
--- a/include/config_sample.h
+++ b/include/config_sample.h
@@ -31,7 +31,11 @@
 // publish values also if they are not changed. 0 = off, n = seconds 
 #define MIN_PUBLISH_TIME 300
 
-
+// NTP Configuration
+#define NTPSERVER "pool.ntp.org" // NTP support disabled if not defined; may be IP or DNS name
+#define TIMEZONE "CET-1CEST,M3.5.0,M10.5.0/3" // Germany Timezone including DST rules (see: https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html)
+//#define GMTOFFSET 3600  // OPTIONAL config w/o TIMEZONE (CET, UTC+1)
+//#define DLOFFSET 3600   // OPTIONAL config w/o TIMEZONE (CEST, UTC+2)
 
 //#define USE_INFLUXDB
 

--- a/include/macros.h
+++ b/include/macros.h
@@ -5,7 +5,6 @@
 #define TEXTIFY(a) DOUBLEESCAPE(a)
 
 // Serial Output configuration
-#define BAUD_RATE 115200
 #ifdef SERIAL_OUT
 #define DEBUG_PRINT(...) Serial.print(__VA_ARGS__)
 #define DEBUG_PRINTLN(...) Serial.println(__VA_ARGS__)

--- a/include/mqtt_handler.h
+++ b/include/mqtt_handler.h
@@ -19,7 +19,6 @@ void mqtt_init();
 #define MQTT_CLTNAME TEXTIFY(CLTNAME)
 extern String mqttname;
 extern String mqtt_main_topic;
-extern long mqttpublishtime_offset;
 extern PubSubClient mqtt_client;
 
 #endif // MQTT_HANDLER_H

--- a/include/version.h
+++ b/include/version.h
@@ -1,1 +1,1 @@
-#define VERSION "0.1.6"
+#define VERSION "0.1.7"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,14 @@
 #include "main.h"
 
-const char* ntpServer = "pool.ntp.org";
-const long  gmtOffset_sec = 3600;  // Deutschland: MEZ (UTC+1)
-const int   daylightOffset_sec = 3600;  // Sommerzeit (UTC+2)
-
+#ifdef NTPSERVER
+const char* ntpServer = NTPSERVER;
+#ifdef TIMEZONE
+const char *time_zone = TIMEZONE;
+#else
+const long  gmtOffset_sec = GMTOFFSET;
+const int   daylightOffset_sec = DLOFFSET;
+#endif
+#endif //NTPSERVER
 
 void setup() {
 #ifdef SERIAL_OUT
@@ -26,10 +31,16 @@ void setup() {
     // WIFI Setup
     init_wifi();
 
-    // Get the current time
+#ifdef NTPSERVER
+    // NTP Setup
+#ifdef TIMEZONE
+    configTzTime(time_zone, ntpServer);
+#else
     configTime(gmtOffset_sec, daylightOffset_sec, ntpServer);
+#endif
     DEBUG_PRINTLN("NTP-Time synced");
-
+#endif //NTPSERVER
+    
     mqtt_init();
 
 #ifdef USE_RS485


### PR DESCRIPTION
- NTP config now in config_sample.h
- added TZconfig for NTP
- minor bugfixes (wrong data types for vars, unused vars removed)
- publishing ESP reset-reason to status/reset_reason